### PR TITLE
Bump 'nanoid' (v3.1.12)

### DIFF
--- a/examples/import-third-party-modules/index.js
+++ b/examples/import-third-party-modules/index.js
@@ -1,5 +1,5 @@
 import { Selector } from 'testcafe';
-import nanoid from 'nanoid';
+import { nanoid } from 'nanoid';
 
 fixture `Import third-party modules`
     .page `https://devexpress.github.io/testcafe/example/`;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.17.19",
-    "nanoid": "^2.1.9",
+    "nanoid": "^3.1.12",
     "testcafe": "^1.8.8"
   },
   "scripts": {


### PR DESCRIPTION
[3.0 Migration Guide](https://github.com/ai/nanoid/releases/tag/3.0.0)