### PR TITLE
"Get text content from multiple elements" example

### DIFF
--- a/examples/get-content-from-multiple-elements/README.md
+++ b/examples/get-content-from-multiple-elements/README.md
@@ -4,7 +4,7 @@
 
 **Tested Page**: [index.html](index.html)
 
-This example shows how to extract text content from all items in an `<ul>` list.
+This example shows how to extract text content from every item in an unordered list (`<ul>`) and compare it with the expected content.
 
 The tested page includes a `<ul>` with three `<li>` elements.
 
@@ -17,7 +17,6 @@ During the test the `getTextFromElements` function takes a TestCafe Selector as 
 * Element Identification and Actions:
   * [Selector](https://devexpress.github.io/testcafe/documentation/reference/test-api/selector/) Object
   * [Selector.find](https://devexpress.github.io/testcafe/documentation/reference/test-api/selector/find.html) Method.
+  * [Selector.nth](https://devexpress.github.io/testcafe/documentation/reference/test-api/selector/nth.html) Method.
 * Assertion and Evaluation:
   * [t.expect.eql](https://devexpress.github.io/testcafe/documentation/reference/test-api/testcontroller/expect/eql.html) Method
-* Custom Scripts:
-  * [ClientFunction](https://devexpress.github.io/testcafe/documentation/reference/test-api/clientfunction/) Object

--- a/examples/get-content-from-multiple-elements/README.md
+++ b/examples/get-content-from-multiple-elements/README.md
@@ -2,8 +2,22 @@
 
 **Test Code**: [index.js](index.js)
 
+**Tested Page**: [index.html](index.html)
+
 This example shows how to extract text content from all items in an `<ul>` list.
 
-`getTextFromElements` is a function that takes a TestCafe Selector as an argument and returns an array of strings: the `textContent` of each element that matches the `selector`.
+The tested page includes a `<ul>` with three `<li>` elements.
 
-The test checks if the resulting list matches an expected one.
+During the test the `getTextFromElements` function takes a TestCafe Selector as an argument and returns an array of strings: the `textContent` of each element that matches the `selector`. The test checks if the resulting list matches an expected one with the `t.expect.eql` method.
+
+## TestCafe API Used in This Example
+
+* Test Structure:
+  * [Fixture.page](https://devexpress.github.io/testcafe/documentation/reference/test-api/fixture/page.html) Method
+* Element Identification and Actions:
+  * [Selector](https://devexpress.github.io/testcafe/documentation/reference/test-api/selector/) Object
+  * [Selector.find](https://devexpress.github.io/testcafe/documentation/reference/test-api/selector/find.html) Method.
+* Assertion and Evaluation:
+  * [t.expect.eql](https://devexpress.github.io/testcafe/documentation/reference/test-api/testcontroller/expect/eql.html) Method
+* Custom Scripts:
+  * [ClientFunction](https://devexpress.github.io/testcafe/documentation/reference/test-api/clientfunction/) Object

--- a/examples/get-content-from-multiple-elements/README.md
+++ b/examples/get-content-from-multiple-elements/README.md
@@ -1,0 +1,9 @@
+# Get Content From Multiple Elements
+
+**Test Code**: [index.js](index.js)
+
+This example shows how to extract text content from all items in an `<ul>` list.
+
+`getTextFromElements` is a function that takes a TestCafe Selector as an argument and returns an array of strings: the `textContent` of each element that matches the `selector`.
+
+The test checks if the resulting list matches an expected one.

--- a/examples/get-content-from-multiple-elements/index.html
+++ b/examples/get-content-from-multiple-elements/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <ul id='ul'>
+            <li>hello</li>
+            <li>world</li>
+            <li>!</li>
+        </ul>
+    </body>
+</html>

--- a/examples/get-content-from-multiple-elements/index.js
+++ b/examples/get-content-from-multiple-elements/index.js
@@ -3,19 +3,15 @@ import { Selector } from 'testcafe';
 fixture `Get content from multiple elements`
     .page `./index.html`;
 
-async function getTextFromElements (selector) {
-    const result = [];
-
-    for (let i = 0; i < await selector.count; i++) {
-        result.push(await selector.nth(i).textContent);
-    }
-
-    return result;
-}
-
 test('Get text from all items in the <ul> list', async t => {
+    const expectedContent    = ['hello', 'word', '!'];
     const liElementsSelector = Selector('#ul').find('li');
 
-    await t
-        .expect(await getTextFromElements(liElementsSelector)).eql(['hello', 'world', '!']);
+    await t.expect(liElementsSelector.count).eql(expectedContent.length);
+
+    const nodeCount = await liElementsSelector.count;
+
+    for (let i = 0; i < nodeCount; i++) {
+        await t.expect(liElementsSelector.nth(i).textContent).eql(expectedContent[i]);
+    }
 });

--- a/examples/get-content-from-multiple-elements/index.js
+++ b/examples/get-content-from-multiple-elements/index.js
@@ -4,7 +4,7 @@ fixture `Get content from multiple elements`
     .page `./index.html`;
 
 test('Get text from all items in the <ul> list', async t => {
-    const expectedContent    = ['hello', 'word', '!'];
+    const expectedContent    = ['hello', 'world', '!'];
     const liElementsSelector = Selector('#ul').find('li');
 
     await t.expect(liElementsSelector.count).eql(expectedContent.length);

--- a/examples/get-content-from-multiple-elements/index.js
+++ b/examples/get-content-from-multiple-elements/index.js
@@ -1,0 +1,21 @@
+import { Selector } from 'testcafe';
+
+fixture `Get content from multiple elements`
+    .page `./index.html`;
+
+async function getTextFromElements (selector) {
+    const result = [];
+
+    for (let i = 0; i < await selector.count; i++) {
+        result.push(await selector.nth(i).textContent);
+    }
+
+    return result;
+}
+
+test('Get text from all items in the <ul> list', async t => {
+    const liElementsSelector = Selector('#ul').find('li');
+
+    await t
+        .expect(await getTextFromElements(liElementsSelector)).eql(['hello', 'world', '!']);
+});


### PR DESCRIPTION
This example shows how to extract text content from all items in an `<ul>` list.

`getTextFromElements` is a function that takes a TestCafe Selector as an argument and returns an array of strings: the `textContent` of each element that matches the `selector`.

The test checks if the resulting list matches an expected one.

Closes #38