### PR TITLE
add: an example on how to delay a mocked response

### DIFF
--- a/examples/delay-mocked-response/README.md
+++ b/examples/delay-mocked-response/README.md
@@ -2,4 +2,4 @@
 
 **Test Code**: [delay-mock-response.js](delay-mocked-response.js)
 
-This example shows how to delay mocked response for particular requests by the given duration.
+This example shows how to delay a mocked response for particular requests by the given duration.

--- a/examples/delay-mocked-response/README.md
+++ b/examples/delay-mocked-response/README.md
@@ -1,0 +1,5 @@
+# Delay Mocked Response
+
+**Test Code**: [delay-mock-response.js](delay-mocked-response.js)
+
+This example shows how to delay mocked response for particular requests by the given duration.

--- a/examples/delay-mocked-response/delay-mocked-response.js
+++ b/examples/delay-mocked-response/delay-mocked-response.js
@@ -1,0 +1,27 @@
+import { Selector, RequestMock } from 'testcafe';
+import delay from 'delay';
+
+const MOCK_RESPONSE_DELAY = 5000;
+
+const mock = RequestMock()
+    .onRequestTo(/request/)
+    .respond(async (req, res) => {
+        await delay(MOCK_RESPONSE_DELAY);
+
+        res.setBody('mocked content');
+    });
+
+fixture `Delay mocked response`
+    .page `http://localhost:3000/examples/delay-mocked-response/index.html`;
+
+test.requestHooks(mock)
+('Check that the mocked response was delayed', async (t) => {
+    await t
+        .click('#send-request')
+        .expect(Selector('#response').textContent)
+        .eql('mocked content', { timeout: MOCK_RESPONSE_DELAY + 3000 });
+
+    const elapsedTime = await Selector('#elapsed-time').textContent;
+
+    await t.expect(parseInt(elapsedTime, 10)).gte(MOCK_RESPONSE_DELAY);
+});

--- a/examples/delay-mocked-response/index.html
+++ b/examples/delay-mocked-response/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <button id="send-request">Send request</button>
+    <div>Elapsed time: <span id="elapsed-time"></span></div>
+    <div id="response"></div>
+    <div id="error"></div>
+    <script>
+        var sendRequestBtn  = document.getElementById('send-request');
+        var elapsedTimeSpan = document.getElementById('elapsed-time');
+        var errorDiv        = document.getElementById('error');
+        var responseDiv     = document.getElementById('response');
+
+        sendRequestBtn.addEventListener('click', function () {
+            var dateMark = Date.now();
+
+            fetch('/request')
+                .then(res => res.text())
+                .then(body => {
+                    elapsedTimeSpan.textContent = (Date.now() - dateMark).toString();
+                    responseDiv.textContent     = body;
+                })
+                .catch(err => {
+                    errorDiv.textContent = err.toString();
+                })
+        });
+    </script>
+</body>
+</html>

--- a/examples/delay-mocked-response/request.html
+++ b/examples/delay-mocked-response/request.html
@@ -1,0 +1,1 @@
+actual content

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "npm run examples && npm run mock-camera-microphone-access"
   },
   "devDependencies": {
+    "delay": "^5.0.0",
     "mockdate": "^2.0.5",
     "multiparty": "^4.2.2"
   }


### PR DESCRIPTION
An example on how to delay a mocked response using a custom response function of a request mocker (separated from the https://github.com/DevExpress/testcafe/issues/2425 thread).