### PR TITLE
fix: fixed unstable tests

### DIFF
--- a/detached-examples/multiuser-scenario/index.js
+++ b/detached-examples/multiuser-scenario/index.js
@@ -1,6 +1,5 @@
 const createTestCafe = require('testcafe');
 
-
 class User {
     constructor (name, fileName, browser) {
         this.name     = name;
@@ -44,7 +43,9 @@ class User {
     }
 }
 
-const scenarios = new Map();
+const scenarios = global.scenarios || new Map();
+
+global.scenarios = scenarios;
 
 class Scenario {
     constructor (description) {

--- a/detached-examples/multiuser-scenario/index.js
+++ b/detached-examples/multiuser-scenario/index.js
@@ -43,9 +43,7 @@ class User {
     }
 }
 
-const scenarios = global.scenarios || new Map();
-
-global.scenarios = scenarios;
+global.scenarios = global.scenarios || new Map();
 
 class Scenario {
     constructor (description) {

--- a/detached-examples/multiuser-scenario/package.json
+++ b/detached-examples/multiuser-scenario/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
-    "testcafe": "^1.16.1"
+    "testcafe": "^1.17.1"
   },
   "devDependencies": {}
 }

--- a/detached-examples/multiuser-scenario/package.json
+++ b/detached-examples/multiuser-scenario/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
-    "testcafe": "^1.14.0"
+    "testcafe": "^1.16.1"
   },
   "devDependencies": {}
 }

--- a/detached-examples/multiuser-scenario/test/scenario-gist.js
+++ b/detached-examples/multiuser-scenario/test/scenario-gist.js
@@ -5,14 +5,16 @@ const { Scenario } = require('..');
 module.exports = async () => {
     const scenario = new Scenario('An example of synchronizing multiple tests');
 
-    const [user1, user2] = await Promise.all([
+    const [user1, user2, user3] = await Promise.all([
         scenario.createUser('First user', path.join(__dirname, 'first-user-test.js'), 'chrome'),
-        scenario.createUser('Second user', path.join(__dirname, 'second-user-test.js'), 'chrome --incognito')
+        scenario.createUser('Second user', path.join(__dirname, 'second-user-test.js'), 'chrome --incognito'),
+        scenario.createUser('Third user', path.join(__dirname, 'third-user-test.js'), 'chrome --incognito')
     ]);
 
     await Promise.all([
         user1.runStage('Check page load'),
-        user2.runStage('Check page load')
+        user2.runStage('Check page load'),
+        user3.runStage('Check page load')
     ]);
 
     await user1.runStage('Type a color and send it');
@@ -21,6 +23,10 @@ module.exports = async () => {
     await user2.runStage('Type a color and send it');
     await user2.runStage('Check result');
 
+    await user3.runStage('Type a color and send it');
+    await user3.runStage('Check result');
+
     user1.runStage('End');
     user2.runStage('End');
+    user3.runStage('End');
 };

--- a/detached-examples/multiuser-scenario/test/third-user-test.js
+++ b/detached-examples/multiuser-scenario/test/third-user-test.js
@@ -1,0 +1,30 @@
+const { Selector } = require('testcafe');
+
+const { getScenario } = require('..');
+
+const scenario = getScenario('An example of synchronizing multiple tests');
+const stage    = scenario.initUser('Third user');
+
+fixture`Third fixture`
+    .page('http://localhost:3000');
+
+const input = Selector('input');
+const h1    = Selector('h1');
+
+test('test', async t => {
+    await stage('Check page load');
+
+    await t.expect(input.exists).ok();
+
+    await stage('Type a color and send it');
+
+    await t
+        .typeText(input, 'red')
+        .pressKey('enter');
+
+    await stage('Check result');
+
+    await t.expect(h1.innerText).eql('Not ok!');
+
+    await stage('End');
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mock-camera-microphone-access": " testcafe --hostname localhost \"chrome --use-fake-ui-for-media-stream --use-fake-device-for-media-stream\" detached-examples/mock-camera-microphone-access/mock-camera-microphone-access.js",
     "extended-error-tracking": "testcafe --skip-js-errors chrome detached-examples/extended-error-tracking/index.js",
     "multiuser-scenario": "node detached-examples/multiuser-scenario/test",
-    "test": "npm run lint & npm run examples && npm run mock-camera-microphone-access && npm run extended-error-tracking && npm run multiuser-scenario",
+    "test": "npm run lint & npm run examples && npm run multiuser-scenario && npm run mock-camera-microphone-access && npm run extended-error-tracking",
     "lint": "eslint examples/**/*.js detached-examples/**/*.js",
     "lint:fix": "eslint --fix examples/**/*.js detached-examples/**/*.js"
   },


### PR DESCRIPTION
Based on @dositec research:
 - https://www.screencast.com/t/NvfLqaTFIS (hang [multiuser-scenario](https://github.com/DevExpress/testcafe-examples/tree/master/detached-examples/multiuser-scenario));
 - https://www.screencast.com/t/To7GMzKAPgSj (failure [mock-camera-microphone-access](https://github.com/DevExpress/testcafe-examples/tree/master/detached-examples/mock-camera-microphone-access))

Both bugs are rarely reproduced and not on all devices. I was able to reproduce them in a virtual machine running WIN10.

As for the first bug, then most likely it has the same reason that I fixed [here](https://github.com/DevExpress/testcafe-example-multiuser-scenario/pull/3). I transferred the same changes here.
I could not figure out the reason for the second bug, but it stopped reproducible after I changed the order in which the tests were run.

### Steps to reproduce:
Run multiple times in a virtual machine: `npm test`