### PR TITLE
feat: Add a chained helper methods example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See [Command Line Interface](https://devexpress.github.io/testcafe/documentation
 The repository includes the following examples:
 
 * [Access Element Properties](examples/element-properties)
+* [Chain Helper Methods](examples/chain-helper-methods)
 * [Change Element's Style](examples/change-element-style)
 * [Check If an Image Has Loaded](examples/check-if-image-loaded)
 * [Check the Downloaded File Name and Content](examples/check-downloaded-file-name-and-content)

--- a/detached-examples/multiuser-scenario/index.js
+++ b/detached-examples/multiuser-scenario/index.js
@@ -80,7 +80,7 @@ class Scenario {
 
 function getScenario (description) {
     const scenario = global.scenarios.get(description);
-
+    
     if (scenario)
         return scenario;
 

--- a/detached-examples/multiuser-scenario/test/scenario-gist.js
+++ b/detached-examples/multiuser-scenario/test/scenario-gist.js
@@ -6,9 +6,9 @@ module.exports = async () => {
     const scenario = new Scenario('An example of synchronizing multiple tests');
 
     const [user1, user2, user3] = await Promise.all([
-        scenario.createUser('First user', path.join(__dirname, 'first-user-test.js'), 'chrome'),
-        scenario.createUser('Second user', path.join(__dirname, 'second-user-test.js'), 'chrome --incognito'),
-        scenario.createUser('Third user', path.join(__dirname, 'third-user-test.js'), 'chrome --incognito')
+        scenario.createUser('First user', path.join(__dirname, 'first-user-test.js'), 'chrome:headless'),
+        scenario.createUser('Second user', path.join(__dirname, 'second-user-test.js'), 'chrome:headless --incognito'),
+        scenario.createUser('Third user', path.join(__dirname, 'third-user-test.js'), 'chrome:headless --incognito')
     ]);
 
     await Promise.all([

--- a/examples/chain-helper-methods/README.md
+++ b/examples/chain-helper-methods/README.md
@@ -1,4 +1,4 @@
-# Extract Reused Code to Helper Functions
+# Chain helper methods
 
 **Test Code**: [index.js](index.js)
 

--- a/examples/chain-helper-methods/README.md
+++ b/examples/chain-helper-methods/README.md
@@ -6,4 +6,4 @@ This example shows how to extract test code to chained class methods defined in 
 
 The `index.js` test file imports a helper class from `helper.js`. These helper methods execute test actions like [t.click](https://devexpress.github.io/testcafe/documentation/test-api/actions/click.html) or [t.typeText](https://devexpress.github.io/testcafe/documentation/test-api/actions/type-text.html). The helper methods calls can be chained like it can be done with test controller's methods.
 
-Note that the [test controller instance](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#test-controller) is imported from the `testcafe` module. You don't need to pass `t` to helper functions because TestCafe can resolve the current test context and provide the correct test controller instance.
+Note that we import the [test controller](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#test-controller) object into the helper file. That way, helper functions connect to the correct test controller instance without additional invocations of the `t` object.

--- a/examples/chain-helper-methods/README.md
+++ b/examples/chain-helper-methods/README.md
@@ -1,0 +1,9 @@
+# Extract Reused Code to Helper Functions
+
+**Test Code**: [index.js](index.js)
+
+This example shows how to extract test code to chained class methods defined in a separate class.
+
+The `index.js` test file imports a helper class from `helper.js`. These helper methods execute test actions like [t.click](https://devexpress.github.io/testcafe/documentation/test-api/actions/click.html) or [t.typeText](https://devexpress.github.io/testcafe/documentation/test-api/actions/type-text.html). The helper methods calls can be chained like it can be done with test controller's methods.
+
+Note that the [test controller instance](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#test-controller) is imported from the `testcafe` module. You don't need to pass `t` to helper functions because TestCafe can resolve the current test context and provide the correct test controller instance.

--- a/examples/chain-helper-methods/README.md
+++ b/examples/chain-helper-methods/README.md
@@ -4,6 +4,6 @@
 
 This example shows how to extract test code to chained class methods defined in a separate class.
 
-The `index.js` test file imports a helper class from `helper.js`. These helper methods execute test actions like [t.click](https://devexpress.github.io/testcafe/documentation/test-api/actions/click.html) or [t.typeText](https://devexpress.github.io/testcafe/documentation/test-api/actions/type-text.html). The helper methods calls can be chained like it can be done with test controller's methods.
+The `index.js` test file imports a Helper class from `helper.js`. The helper contains customized test actions ([t.click](https://testcafe.io/documentation/402710/reference/test-api/testcontroller/click?search#header) and [t.typeText](https://testcafe.io/documentation/402674/reference/test-api/testcontroller/typetext?search#header)), as well as additional methods that facilitate method chaining.
 
 Note that we import the [test controller](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#test-controller) object into the helper file. That way, helper functions connect to the correct test controller instance without additional invocations of the `t` object.

--- a/examples/chain-helper-methods/README.md
+++ b/examples/chain-helper-methods/README.md
@@ -2,7 +2,7 @@
 
 **Test Code**: [index.js](index.js)
 
-This example shows how to extract test code to chained class methods defined in a separate class.
+This example demonstrates how to chain helper methods defined in a separate file.
 
 The `index.js` test file imports a Helper class from `helper.js`. The helper contains customized test actions ([t.click](https://testcafe.io/documentation/402710/reference/test-api/testcontroller/click?search#header) and [t.typeText](https://testcafe.io/documentation/402674/reference/test-api/testcontroller/typetext?search#header)), as well as additional methods that facilitate method chaining.
 

--- a/examples/chain-helper-methods/helper.js
+++ b/examples/chain-helper-methods/helper.js
@@ -1,0 +1,37 @@
+import { Selector, t } from 'testcafe';
+    
+export class Helper {
+    constructor () {
+        this.queue = Promise.resolve();
+
+        this.developerName = Selector('#developer-name');
+        this.submitButton  = Selector('#submit-button');
+        this.articleHeader = Selector('#article-header');
+    }
+
+    _chain (callback) {
+        this.queue = this.queue.then(callback);
+
+        return this;
+    }
+
+    then (callback) {
+        return callback(this.queue);
+    }
+
+    navigateTo (url) { 
+        return this._chain(async () => await t.navigateTo(url));
+    }
+
+    typeName (name) { 
+        return this._chain(async () => await t.typeText(this.developerName, name));
+    }
+
+    submit () {
+        return this._chain(async () => await t.click(this.submitButton));
+    }
+
+    checkName (name) {
+        return this._chain(async () => await t.expect(this.articleHeader.textContent).contains(name));
+    }
+}

--- a/examples/chain-helper-methods/index.js
+++ b/examples/chain-helper-methods/index.js
@@ -1,0 +1,13 @@
+import { Helper } from './helper';
+    
+fixture`Chain Helper Methods`;
+
+const helper = new Helper();
+
+test('Fill form', async () => {
+    await helper
+        .navigateTo('http://devexpress.github.io/testcafe/example/')
+        .typeName('John')
+        .submit()
+        .checkName('John');
+});

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "testcafe": "^1.16.1"
   },
   "scripts": {
-    "examples": "testcafe chrome examples -a \"node server/index.js\"",
-    "mock-camera-microphone-access": " testcafe --hostname localhost \"chrome --use-fake-ui-for-media-stream --use-fake-device-for-media-stream\" detached-examples/mock-camera-microphone-access/mock-camera-microphone-access.js",
-    "extended-error-tracking": "testcafe --skip-js-errors chrome detached-examples/extended-error-tracking/index.js",
+    "examples": "testcafe chrome:headless examples -a \"node server/index.js\"",
+    "mock-camera-microphone-access": " testcafe --hostname localhost \"chrome:headless --use-fake-ui-for-media-stream --use-fake-device-for-media-stream\" detached-examples/mock-camera-microphone-access/mock-camera-microphone-access.js",
+    "extended-error-tracking": "testcafe --skip-js-errors chrome:headless detached-examples/extended-error-tracking/index.js",
     "multiuser-scenario": "node detached-examples/multiuser-scenario/test",
     "set-window-size-for-all-tests": "testcafe chrome detached-examples/set-window-size-for-all-tests/set-window-size-for-all-tests.js --config-file detached-examples/set-window-size-for-all-tests/.testcaferc.js",
     "test": "npm run lint & npm run examples && npm run multiuser-scenario && npm run mock-camera-microphone-access && npm run extended-error-tracking && npm run set-window-size-for-all-tests",


### PR DESCRIPTION
This example is based on this article: https://blog.devgenius.io/async-method-chaining-in-node-8c24c8c3a28d and this question: https://stackoverflow.com/questions/70260331/fluent-pagemodel-api-with-testcafe

I changed browser name to `chrome:headless` because the Linux version installed on the CI machine does not have graphic subsystem.