### PR TITLE
feat: added kerberos authenticate example

### DIFF
--- a/.github/workflows/kerrberos-auth.yml
+++ b/.github/workflows/kerrberos-auth.yml
@@ -1,0 +1,24 @@
+name: Kerberos Authentication
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Run Tests
+        run: npm run kerberos-auth

--- a/README.md
+++ b/README.md
@@ -88,4 +88,5 @@ Below are the examples that run in Chrome or Firefox only or require additional 
 * [Extended Client-Side Error Tracking](detached-examples/extended-error-tracking)
 * [Mock Camera/Microphone Access](detached-examples/mock-camera-microphone-access)
 * [Multi-User Tests](detached-examples/multiuser-scenario)
+* [Kerberos authenticate](detached-examples/kerberos-auth)
 

--- a/detached-examples/kerberos-auth/.gitignore
+++ b/detached-examples/kerberos-auth/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/detached-examples/kerberos-auth/client/.gitignore
+++ b/detached-examples/kerberos-auth/client/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/detached-examples/kerberos-auth/client/index.js
+++ b/detached-examples/kerberos-auth/client/index.js
@@ -1,0 +1,37 @@
+const { execSync } = require('child_process');
+
+const express  = require('express');
+const kerberos = require('kerberos');
+
+const service = 'HTTP@testcafe.io';
+
+const kerberosClients = new Map();
+
+function parseQuery (req) {
+    const args = req._parsedUrl.query.split('&');
+
+    return args.reduce((result, arg) => {
+        const [key, value] = arg.split('=');
+
+        result[key] = value;
+
+        return result;
+    }, {});
+}
+
+const app = express();
+
+app.get('/get-token', async (req, res) => {
+    const { principal, password } = parseQuery(req);
+
+    execSync(`echo -n "${password}" | kinit "${principal}"`);
+
+    const kerberosClient = await kerberos.initializeClient(service, {});
+    const kerberosToken  = await kerberosClient.step('');
+
+    kerberosClients.set(principal, kerberosClient);
+
+    res.send(kerberosToken);
+});
+
+app.listen(5000);

--- a/detached-examples/kerberos-auth/client/package.json
+++ b/detached-examples/kerberos-auth/client/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "clinet",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": {
+    "name": "Developer Express Inc.",
+    "url": "https://www.devexpress.com/"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2",
+    "kerberos": "^2.0.1"
+  }
+}

--- a/detached-examples/kerberos-auth/index.js
+++ b/detached-examples/kerberos-auth/index.js
@@ -1,0 +1,65 @@
+const { execSync } = require('node:child_process');
+
+const createTestCafe = require('testcafe');
+
+async function runTestCafe () {
+    const testcafe = await createTestCafe('localhost', 0, 0);
+    const runner   = testcafe.createRunner();
+
+    const failedCount = await runner
+        .src('test.js')
+        .browsers('chrome:headless')
+        .run();
+
+    await testcafe.close();
+
+    return !!failedCount;
+}
+
+function startServer () {
+    execSync('docker run -d -it --name server -p 3000:5000 testcafe/testcafe-examples_kerberos-server');
+
+    execSync('docker exec server /etc/init.d/krb5-admin-server restart');
+    execSync('docker exec server /etc/init.d/krb5-kdc restart');
+
+    execSync('docker exec server mkdir home/server');
+
+    execSync('docker cp server/index.js server:home/server/index.js');
+    execSync('docker cp server/package.json server:home/server/package.json');
+
+    execSync('docker exec server sh -c "cd /home/server && npm i"');
+    execSync('docker exec -d server node /home/server');
+}
+
+function startClient () {
+    execSync('docker run -d -it --name client -p 3001:5000 testcafe/testcafe-examples_kerberos-client');
+
+    execSync('docker exec client sh -c "echo \'172.17.0.2\ttestcafe.io\' >> etc/hosts"');
+
+    execSync('docker exec client mkdir home/client');
+
+    execSync('docker cp client/index.js client:home/client/index.js');
+    execSync('docker cp client/package.json client:home/client/package.json');
+
+    execSync('docker exec client sh -c "cd /home/client && npm i"');
+    execSync('docker exec -d client node /home/client');
+}
+
+function removeContainers () {
+    execSync('docker rm -f server');
+    execSync('docker rm -f client');
+}
+
+async function start () {
+    startServer();
+    startClient();
+
+    const isFailed = await runTestCafe();
+
+    removeContainers();
+
+    if (isFailed)
+        throw 'Tests failed';
+}
+
+start();

--- a/detached-examples/kerberos-auth/kerberos-auth-hook.js
+++ b/detached-examples/kerberos-auth/kerberos-auth-hook.js
@@ -1,0 +1,30 @@
+const http = require('http');
+
+const { RequestHook } = require('testcafe');
+
+const principal = 'testcafe-user';
+const password  = 'testcafe-pass';
+
+async function getKerberosToken () {
+    return new Promise(resolve => {
+        http.get(`http://localhost:3001/get-token?principal=${principal}&password=${password}`, res => {
+            const data = [];
+
+            res.on('data', chank => data.push(chank));
+            res.on('end', () => resolve(data.join('')));
+        });
+    });
+}
+
+export class KerberosAuth extends RequestHook {
+    constructor () {
+        super(/login/);
+    }
+
+    async onRequest (event) {
+        event.requestOptions.headers.authorization = 'Negotiate ' + await getKerberosToken();
+    }
+
+    async onResponse () {
+    }
+}

--- a/detached-examples/kerberos-auth/package.json
+++ b/detached-examples/kerberos-auth/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "kerberos-auth",
+  "version": "1.0.0",
+  "description": "Kerberos authentication with request hooks",
+  "main": "index.js",
+  "scripts": {
+    "start": "npm i && node ."
+  },
+  "author": {
+    "name": "Developer Express Inc.",
+    "url": "https://www.devexpress.com/"
+  },
+  "license": "MIT",
+  "keywords": [
+    "kerberos",
+    "docker",
+    "testcafe"
+  ],
+  "dependencies": {
+    "testcafe": "*"
+  }
+}

--- a/detached-examples/kerberos-auth/readme.md
+++ b/detached-examples/kerberos-auth/readme.md
@@ -1,33 +1,38 @@
-### To run this example, use:
+# Authenticate a user with Kerberos
+## How to run this example
+If your current working directory is `testcafe-examples`, execute the following command:
 ```
 npm run kerberos-auth
 ```
-if you are in `testcafe-examples`
-or
+If your current working directory is `testcafe-examples/detached-examples/kerberos-auth`, execute the following command:
+
 ```
 npm start
 ```
-if you are in `testcafe-examples/detached-examples/kerberos-auth`.
 
-### This example demonstrates the ability to authenticate to a site using Kerberos.
-It uses two docker containers. One hosts the application server. In the other, there is a kerberos client and a small server with which TestCafe can get a kerberos token.
+## Example contents
+The example demonstrates how to implement Kerberos user authentication in a TestCafe test. It utilizes two Docker containers:
 
-The [testcafe/testcafe-examples_kerberos-server](https://hub.docker.com/r/testcafe/testcafe-examples_kerberos-server) container is based on the Ubuntu image and includes the following packages:
-  - `krb5-kdc` - server issuing kerberos tokens;
-  - `krb5-admin-server` - a server that stores a database of users (principals);
-  - `curl`, `nvm`, `nodejs` and `npm`.
+1. The [testcafe/testcafe-examples_kerberos-server](https://hub.docker.com/r/testcafe/testcafe-examples_kerberos-server) container hosts the application server. It is based on the Ubuntu image and includes the following packages:
+    -  A Kerberos token generator (`krb5-kdc`).
+    -  A Kerberos database server that stores user credentials (`krb5-admin-server`).
+    -  A set of common CLI tools (`curl`, `nvm`, `nodejs`, `npm`).
 
-The server is already configured and a single principal has been added to its database:
-**principal**: `testcafe-user`
-**password**: `testcafe-pass`
+  The Kerberos server comes pre-configured. The database contains a single principal:
+  **principal**: `testcafe-user`
+  **password**: `testcafe-pass`
 
-The [testcafe/testcafe-examples_kerberos-client](https://hub.docker.com/r/testcafe/testcafe-examples_kerberos-client) container is based on Ubuntu and includes the following packages:
-  - `krb5-user` - a utility that can access the kdc server to get a token;
-  - `curl`, `nvm`, `nodejs` and `npm`.
+2. The [testcafe/testcafe-examples_kerberos-client](https://hub.docker.com/r/testcafe/testcafe-examples_kerberos-client) container hosts the Kerberos client. It is based on the Ubuntu image and includes the following packages:
+    - A utility that retrieves the Kerberos token from the token generator (`krb5-user`)
+    - A set of common CLI tools (`curl`, `nvm`, `nodejs`, `npm`).
 
-After running `npm start` the containers will be launched. And the script will copy files from `client` and `server` to them, respectively.
-
-In `server` there is an `express` based server that should serve the page and then validate the kerberos token received from the user.
-
-The `client` contains a small server that TestCafe calls to get a kerberos token. It is separated into a separate container in order to avoid the problems of configuring the Kerberos client on different operating systems.
+  ## Launch script overview
+  
+  This is what happens when you run the `npm start` command: 
+  
+  1. The script launches the `server` container and populates it with files from the `server` folder.
+  2. The script launches the `client` container and populates it with files from the `server` folder.
+  3. The `server` container launches a simple Express.js application, as well as a server that validates Kerberos tokens.
+  4. The `client` container launches an application that obtains Kerberos tokens from the server on behalf of TestCafe.
+  5. The script creates a new TestCafe instance and launches the `test.js` test.
 

--- a/detached-examples/kerberos-auth/readme.md
+++ b/detached-examples/kerberos-auth/readme.md
@@ -1,0 +1,33 @@
+### To run this example, use:
+```
+npm run kerberos-auth
+```
+if you are in `testcafe-examples`
+or
+```
+npm start
+```
+if you are in `testcafe-examples/detached-examples/kerberos-auth`.
+
+### This example demonstrates the ability to authenticate to a site using Kerberos.
+It uses two docker containers. One hosts the application server. In the other, there is a kerberos client and a small server with which TestCafe can get a kerberos token.
+
+The [testcafe/testcafe-examples_kerberos-server](https://hub.docker.com/r/testcafe/testcafe-examples_kerberos-server) container is based on the Ubuntu image and includes the following packages:
+  - `krb5-kdc` - server issuing kerberos tokens;
+  - `krb5-admin-server` - a server that stores a database of users (principals);
+  - `curl`, `nvm`, `nodejs` and `npm`.
+
+The server is already configured and a single principal has been added to its database:
+**principal**: `testcafe-user`
+**password**: `testcafe-pass`
+
+The [testcafe/testcafe-examples_kerberos-client](https://hub.docker.com/r/testcafe/testcafe-examples_kerberos-client) container is based on Ubuntu and includes the following packages:
+  - `krb5-user` - a utility that can access the kdc server to get a token;
+  - `curl`, `nvm`, `nodejs` and `npm`.
+
+After running `npm start` the containers will be launched. And the script will copy files from `client` and `server` to them, respectively.
+
+In `server` there is an `express` based server that should serve the page and then validate the kerberos token received from the user.
+
+The `client` contains a small server that TestCafe calls to get a kerberos token. It is separated into a separate container in order to avoid the problems of configuring the Kerberos client on different operating systems.
+

--- a/detached-examples/kerberos-auth/server/.gitignore
+++ b/detached-examples/kerberos-auth/server/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/detached-examples/kerberos-auth/server/index.js
+++ b/detached-examples/kerberos-auth/server/index.js
@@ -1,0 +1,43 @@
+const { promises: fs } = require('node:fs');
+
+const express  = require('express');
+const kerberos = require('kerberos');
+
+const service = 'HTTP@testcafe.io';
+
+const app = express();
+
+app.get('/', (req, res) => {
+    res.send('<a href="/login">Login</a>');
+});
+
+app.get('/login', async (req, res) => {
+    if (!req.headers.authorization) {
+        res.set('WWW-Authenticate', 'Negotiate');
+        res.status(401).send();
+    }
+    else {
+        const authHeader     = req.headers.authorization;
+        const clientToken    = authHeader.substring(10);
+        const kerberosServer = await kerberos.initializeServer(service);
+        const serverToken    = await kerberosServer.step(clientToken);
+
+        res.set('WWW-Authenticate', 'Negotiate ' + serverToken);
+        res.send(`Hello, ${kerberosServer.username}!`);
+    }
+});
+
+app.listen(5000);
+
+//This hack is needed for stable work on Github Actions runner (ubuntu):
+//for some reason, kdc server is trying to access the principals database.
+//This does not happen when running locally on Windows.
+async function replaceHost () {
+    const oldHosts = await fs.readFile('/etc/hosts', 'utf-8');
+    const hostname = await fs.readFile('/etc/hostname', 'utf-8');
+    const newHosts = oldHosts.replaceAll(hostname, 'testcafe.io\n');
+
+    await fs.writeFile('/etc/hosts', newHosts);
+}
+
+replaceHost();

--- a/detached-examples/kerberos-auth/server/package.json
+++ b/detached-examples/kerberos-auth/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": {
+    "name": "Developer Express Inc.",
+    "url": "https://www.devexpress.com/"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2",
+    "kerberos": "^2.0.1"
+  }
+}

--- a/detached-examples/kerberos-auth/test.js
+++ b/detached-examples/kerberos-auth/test.js
@@ -1,0 +1,13 @@
+import { Selector } from 'testcafe';
+
+import { KerberosAuth } from './kerberos-auth-hook';
+
+fixture `Kerberos authenticate`
+    .page `localhost:3000`
+    .requestHooks(new KerberosAuth());
+
+test('Auth', async t => {
+    await t
+        .click('a')
+        .expect(Selector('body').innerText).contains('Hello, testcafe-user@TESTCAFE.IO!');
+});

--- a/package.json
+++ b/package.json
@@ -17,15 +17,16 @@
     "mock-camera-microphone-access": " testcafe --hostname localhost \"chrome:headless --use-fake-ui-for-media-stream --use-fake-device-for-media-stream\" detached-examples/mock-camera-microphone-access/mock-camera-microphone-access.js",
     "extended-error-tracking": "testcafe --skip-js-errors chrome:headless detached-examples/extended-error-tracking/index.js",
     "multiuser-scenario": "node detached-examples/multiuser-scenario/test",
+    "kerberos-auth": "cd detached-examples/kerberos-auth && npm start",
     "set-window-size-for-all-tests": "testcafe chrome detached-examples/set-window-size-for-all-tests/set-window-size-for-all-tests.js --config-file detached-examples/set-window-size-for-all-tests/.testcaferc.js",
     "test": "npm run lint & npm run examples && npm run multiuser-scenario && npm run mock-camera-microphone-access && npm run extended-error-tracking && npm run set-window-size-for-all-tests",
     "lint": "eslint examples/**/*.js detached-examples/**/*.js",
     "lint:fix": "eslint --fix examples/**/*.js detached-examples/**/*.js"
   },
   "devDependencies": {
-    "express": "^4.17.1",
     "delay": "^5.0.0",
     "eslint": "^6.8.0",
+    "express": "^4.17.1",
     "mockdate": "^2.0.5",
     "multiparty": "^4.2.2"
   }


### PR DESCRIPTION
# Authenticate a user with Kerberos
## How to run this example
If your current working directory is `testcafe-examples`, execute the following command:
```
npm run kerberos-auth
```
If your current working directory is `testcafe-examples/detached-examples/kerberos-auth`, execute the following command:

```
npm start
```

## Example contents
The example demonstrates how to implement Kerberos user authentication in a TestCafe test. It utilizes two Docker containers:

1. The [testcafe/testcafe-examples_kerberos-server](https://hub.docker.com/r/testcafe/testcafe-examples_kerberos-server) container hosts the application server. It is based on the Ubuntu image and includes the following packages:
    -  A Kerberos token generator (`krb5-kdc`).
    -  A Kerberos database server that stores user credentials (`krb5-admin-server`).
    -  A set of common CLI tools (`curl`, `nvm`, `nodejs`, `npm`).

  The Kerberos server comes pre-configured. The database contains a single principal:
  **principal**: `testcafe-user`
  **password**: `testcafe-pass`

2. The [testcafe/testcafe-examples_kerberos-client](https://hub.docker.com/r/testcafe/testcafe-examples_kerberos-client) container hosts the Kerberos client. It is based on the Ubuntu image and includes the following packages:
    - A utility that retrieves the Kerberos token from the token generator (`krb5-user`)
    - A set of common CLI tools (`curl`, `nvm`, `nodejs`, `npm`).

  ## Launch script overview

  This is what happens when you run the `npm start` command: 

  1. The script launches the `server` container and populates it with files from the `server` folder.
  2. The script launches the `client` container and populates it with files from the `server` folder.
  3. The `server` container launches a simple Express.js application, as well as a server that validates Kerberos tokens.
  4. The `client` container launches an application that obtains Kerberos tokens from the server on behalf of TestCafe.
  5. The script creates a new TestCafe instance and launches the `test.js` test.

